### PR TITLE
Feature/arcgis support

### DIFF
--- a/config-example.yaml
+++ b/config-example.yaml
@@ -43,6 +43,15 @@ plugins:
     timeout: 120 # HTTP timeout in seconds
     # api_key: "${CKAN_API_KEY}"  # Optional: CKAN API key for authenticated requests
 
+  # Built-in: ArcGIS Hub (for ArcGIS Hub open data portals)
+  # Examples: hub.arcgis.com, data-boston.hub.arcgis.com
+  arcgis:
+    enabled: false # Set to true to use
+    portal_url: "https://hub.arcgis.com"
+    city_name: "Your City"
+    timeout: 120
+    # token: "${ARCGIS_TOKEN}"  # Optional: Bearer token for private items
+
   # yamllint disable rule:comments-indentation
   # Custom: Add your own plugins here
   # Example:

--- a/config.yaml
+++ b/config.yaml
@@ -1,1 +1,1 @@
-examples/boston-socrata/config.yaml
+examples/dc-arcgis/config.yaml

--- a/plugins/arcgis/__init__.py
+++ b/plugins/arcgis/__init__.py
@@ -1,0 +1,1 @@
+"""ArcGIS Hub plugin for OpenContext."""

--- a/plugins/arcgis/config_schema.py
+++ b/plugins/arcgis/config_schema.py
@@ -1,0 +1,44 @@
+"""Pydantic configuration schema for ArcGIS Hub plugin."""
+
+from typing import Optional
+from urllib.parse import urlparse
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class ArcGISPluginConfig(BaseModel):
+    """Configuration schema for ArcGIS Hub plugin.
+
+    This schema validates ArcGIS Hub plugin configuration from config.yaml.
+    """
+
+    enabled: bool = Field(default=False, description="Whether plugin is enabled")
+    portal_url: str = Field(
+        default="https://hub.arcgis.com",
+        description="Base URL of ArcGIS Hub portal (e.g., https://hub.arcgis.com)",
+    )
+    city_name: str = Field(..., description="Name of the city/organization")
+    timeout: int = Field(
+        default=120, ge=1, le=300, description="HTTP request timeout in seconds"
+    )
+    token: Optional[str] = Field(
+        None, description="Optional Bearer token for authenticated requests"
+    )
+
+    @field_validator("portal_url")
+    @classmethod
+    def validate_url(cls, v: str) -> str:
+        """Validate that URL is well-formed."""
+        if not v:
+            raise ValueError("URL cannot be empty")
+        try:
+            result = urlparse(v)
+            if not result.scheme or not result.netloc:
+                raise ValueError("URL must include scheme (http/https) and hostname")
+            if result.scheme not in ("http", "https"):
+                raise ValueError("URL scheme must be http or https")
+        except Exception as e:
+            raise ValueError(f"Invalid URL format: {e}")
+        return v.rstrip("/")
+
+    model_config = ConfigDict(extra="forbid")

--- a/plugins/arcgis/plugin.py
+++ b/plugins/arcgis/plugin.py
@@ -30,6 +30,13 @@ class ArcGISPlugin(DataPlugin):
     plugin_type = PluginType.OPEN_DATA
     plugin_version = "1.0.0"
 
+    QUERYABLE_TYPES = {
+        "Feature Layer",
+        "Feature Service",
+        "Map Service",
+        "Table",
+    }
+
     def __init__(self, config: Dict[str, Any]) -> None:
         super().__init__(config)
         self.plugin_config: Optional[ArcGISPluginConfig] = None
@@ -131,8 +138,8 @@ class ArcGISPlugin(DataPlugin):
                         "field": {
                             "type": "string",
                             "description": (
-                                'Field to aggregate (e.g. "type", "tags", '
-                                '"categories", "owner", "access")'
+                                "Field to aggregate. Available fields: "
+                                '"type", "tags", "categories", "access"'
                             ),
                         },
                         "q": {
@@ -172,6 +179,7 @@ class ArcGISPlugin(DataPlugin):
                             "type": "integer",
                             "description": "Maximum number of records (default: 100)",
                             "default": 100,
+                            "minimum": 1,
                             "maximum": 1000,
                         },
                     },
@@ -330,11 +338,20 @@ class ArcGISPlugin(DataPlugin):
         filters: Optional[Dict[str, Any]] = None,
         limit: int = 100,
     ) -> List[Dict[str, Any]]:
+        if limit < 1:
+            raise ValueError(f"limit must be at least 1 (got {limit})")
         dataset = await self.get_dataset(resource_id)
         service_url = dataset.get("service_url")
+        ds_type = dataset.get("type", "")
         if not service_url:
             raise ValueError(
                 f"Dataset {resource_id} does not have a queryable Feature Service URL"
+            )
+
+        if ds_type and ds_type not in self.QUERYABLE_TYPES:
+            raise ValueError(
+                f"Dataset type '{ds_type}' is not queryable. "
+                f"query_data only supports: {', '.join(sorted(self.QUERYABLE_TYPES))}."
             )
 
         where_clause = filters.get("where", "1=1") if filters else "1=1"
@@ -343,10 +360,11 @@ class ArcGISPlugin(DataPlugin):
 
         service_url = self._ensure_layer_url(service_url)
         query_url = f"{service_url}/query"
+        record_count = min(limit, 1000)
         params = {
             "where": where_clause,
             "outFields": out_fields,
-            "resultRecordCount": min(limit, 1000),
+            "resultRecordCount": record_count,
             "f": "json",
             "returnGeometry": "false",
         }
@@ -360,7 +378,27 @@ class ArcGISPlugin(DataPlugin):
                 f"{e.response.text}"
             ) from e
 
-        data = response.json()
+        try:
+            data = response.json()
+        except Exception as json_err:
+            content_type = response.headers.get("content-type", "")
+            raise ValueError(
+                f"Feature Service returned non-JSON response "
+                f"(content-type: {content_type}). The dataset URL may not "
+                f"point to a queryable ArcGIS Feature Service."
+            ) from json_err
+
+        error_in_body = data.get("error")
+        if error_in_body:
+            code = error_in_body.get("code", "unknown")
+            msg = error_in_body.get("message", "Unknown error")
+            details = error_in_body.get("details", [])
+            detail_str = "; ".join(details) if details else ""
+            raise RuntimeError(
+                f"Feature Service query failed (code {code}): {msg}"
+                + (f" — {detail_str}" if detail_str else "")
+            )
+
         features = data.get("features", [])
         if not features:
             return []
@@ -372,7 +410,7 @@ class ArcGISPlugin(DataPlugin):
     async def get_aggregations(
         self, field: str, q: Optional[str] = None
     ) -> List[Dict[str, Any]]:
-        params: Dict[str, Any] = {"fields": field}
+        params: Dict[str, Any] = {}
         if q:
             params["q"] = q
 
@@ -389,8 +427,20 @@ class ArcGISPlugin(DataPlugin):
             return []
 
         data = response.json()
-        buckets = data.get("aggregations", {}).get(field, {}).get("buckets", [])
-        return buckets
+        logger.debug(f"Aggregations raw response: {data}")
+
+        aggregations = data.get("aggregations", {})
+        terms = aggregations.get("terms", []) if isinstance(aggregations, dict) else []
+
+        for term_group in terms:
+            if term_group.get("field") == field:
+                raw_buckets = term_group.get("aggregations", [])
+                return [
+                    {"key": b.get("label", ""), "doc_count": b.get("value", 0)}
+                    for b in raw_buckets
+                ]
+
+        return []
 
     # ── Health check ────────────────────────────────────────────────────
 
@@ -508,7 +558,7 @@ class ArcGISPlugin(DataPlugin):
         for bucket in buckets:
             lines.append(
                 f"  {bucket.get('key', 'unknown')}: "
-                f"{bucket.get('doc_count', 0)} dataset(s)"
+                f"{bucket.get('doc_count', bucket.get('count', 0))} dataset(s)"
             )
 
         return "\n".join(lines)

--- a/plugins/arcgis/plugin.py
+++ b/plugins/arcgis/plugin.py
@@ -1,0 +1,514 @@
+"""ArcGIS Hub plugin implementation for OpenContext.
+
+This plugin provides access to ArcGIS Hub open data catalogs
+via the OGC API - Records (Hub Search API) and ArcGIS Feature Services.
+"""
+
+import logging
+import re
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from core.interfaces import DataPlugin, PluginType, ToolDefinition, ToolResult
+from plugins.arcgis.config_schema import ArcGISPluginConfig
+from plugins.arcgis.where_validator import WhereValidator
+
+logger = logging.getLogger(__name__)
+
+
+class ArcGISPlugin(DataPlugin):
+    """Plugin for accessing ArcGIS Hub open data catalogs.
+
+    This plugin implements the DataPlugin interface and provides tools for
+    searching datasets, retrieving dataset metadata, querying Feature Services,
+    and exploring catalog aggregations.
+    """
+
+    plugin_name = "arcgis"
+    plugin_type = PluginType.OPEN_DATA
+    plugin_version = "1.0.0"
+
+    def __init__(self, config: Dict[str, Any]) -> None:
+        super().__init__(config)
+        self.plugin_config: Optional[ArcGISPluginConfig] = None
+        self.hub_client: Optional[httpx.AsyncClient] = None
+        self.feature_client: Optional[httpx.AsyncClient] = None
+
+    async def initialize(self) -> bool:
+        try:
+            self.plugin_config = ArcGISPluginConfig(**self.config)
+
+            headers = {"Accept": "application/json"}
+            feature_headers = {}
+            if self.plugin_config.token:
+                headers["Authorization"] = f"Bearer {self.plugin_config.token}"
+                feature_headers["Authorization"] = f"Bearer {self.plugin_config.token}"
+
+            self.hub_client = httpx.AsyncClient(
+                base_url=self.plugin_config.portal_url,
+                headers=headers,
+                timeout=self.plugin_config.timeout,
+            )
+
+            self.feature_client = httpx.AsyncClient(
+                headers=feature_headers,
+                timeout=self.plugin_config.timeout,
+            )
+
+            response = await self.hub_client.get("/api/search/v1/collections")
+            response.raise_for_status()
+
+            self._initialized = True
+            logger.info(
+                f"ArcGIS Hub plugin initialized successfully for "
+                f"{self.plugin_config.city_name}"
+            )
+            return True
+
+        except Exception as e:
+            logger.error(f"Failed to initialize ArcGIS Hub plugin: {e}", exc_info=True)
+            return False
+
+    async def shutdown(self) -> None:
+        if self.hub_client:
+            await self.hub_client.aclose()
+            self.hub_client = None
+        if self.feature_client:
+            await self.feature_client.aclose()
+            self.feature_client = None
+        self._initialized = False
+        logger.info("ArcGIS Hub plugin shut down")
+
+    def get_tools(self) -> List[ToolDefinition]:
+        city = self.plugin_config.city_name if self.plugin_config else "Unknown"
+        return [
+            ToolDefinition(
+                name="search_datasets",
+                description=f"Search for datasets in {city}'s ArcGIS Hub catalog",
+                input_schema={
+                    "type": "object",
+                    "properties": {
+                        "q": {
+                            "type": "string",
+                            "description": "Full-text search query",
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "description": "Maximum number of results (default: 10)",
+                            "default": 10,
+                            "minimum": 1,
+                            "maximum": 100,
+                        },
+                    },
+                    "required": ["q"],
+                },
+            ),
+            ToolDefinition(
+                name="get_dataset",
+                description="Get metadata for a specific ArcGIS Hub dataset by ID",
+                input_schema={
+                    "type": "object",
+                    "properties": {
+                        "dataset_id": {
+                            "type": "string",
+                            "description": "32-char hex Hub item ID",
+                        },
+                    },
+                    "required": ["dataset_id"],
+                },
+            ),
+            ToolDefinition(
+                name="get_aggregations",
+                description=(
+                    "Get facet counts for a field across the ArcGIS Hub catalog. "
+                    "Useful for exploring available categories, types, or tags."
+                ),
+                input_schema={
+                    "type": "object",
+                    "properties": {
+                        "field": {
+                            "type": "string",
+                            "description": (
+                                'Field to aggregate (e.g. "type", "tags", '
+                                '"categories", "owner", "access")'
+                            ),
+                        },
+                        "q": {
+                            "type": "string",
+                            "description": "Optional search query to scope the aggregation",
+                        },
+                    },
+                    "required": ["field"],
+                },
+            ),
+            ToolDefinition(
+                name="query_data",
+                description=(
+                    "Query records from an ArcGIS Feature Service. Provide the Hub "
+                    "dataset ID — the plugin resolves the Feature Service URL "
+                    "automatically (two-hop). Use get_dataset first to confirm the "
+                    "dataset has a queryable service URL."
+                ),
+                input_schema={
+                    "type": "object",
+                    "properties": {
+                        "dataset_id": {
+                            "type": "string",
+                            "description": "Hub item ID (same as get_dataset)",
+                        },
+                        "where": {
+                            "type": "string",
+                            "description": "SQL WHERE clause for filtering",
+                            "default": "1=1",
+                        },
+                        "out_fields": {
+                            "type": "string",
+                            "description": "Comma-separated field names to return",
+                            "default": "*",
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "description": "Maximum number of records (default: 100)",
+                            "default": 100,
+                            "maximum": 1000,
+                        },
+                    },
+                    "required": ["dataset_id"],
+                },
+            ),
+        ]
+
+    async def execute_tool(
+        self, tool_name: str, arguments: Dict[str, Any]
+    ) -> ToolResult:
+        try:
+            if tool_name == "search_datasets":
+                q = arguments.get("q", "")
+                limit = arguments.get("limit", 10)
+                datasets = await self.search_datasets(q, limit)
+                return ToolResult(
+                    content=[
+                        {"type": "text", "text": self._format_search_results(datasets)}
+                    ],
+                    success=True,
+                )
+
+            elif tool_name == "get_dataset":
+                dataset_id = arguments.get("dataset_id")
+                if not dataset_id:
+                    return ToolResult(
+                        content=[],
+                        success=False,
+                        error_message="dataset_id is required",
+                    )
+                dataset = await self.get_dataset(dataset_id)
+                return ToolResult(
+                    content=[{"type": "text", "text": self._format_dataset(dataset)}],
+                    success=True,
+                )
+
+            elif tool_name == "get_aggregations":
+                field = arguments.get("field")
+                if not field:
+                    return ToolResult(
+                        content=[],
+                        success=False,
+                        error_message="field is required",
+                    )
+                q = arguments.get("q")
+                buckets = await self.get_aggregations(field, q)
+                return ToolResult(
+                    content=[
+                        {
+                            "type": "text",
+                            "text": self._format_aggregations(field, buckets),
+                        }
+                    ],
+                    success=True,
+                )
+
+            elif tool_name == "query_data":
+                dataset_id = arguments.get("dataset_id")
+                if not dataset_id:
+                    return ToolResult(
+                        content=[],
+                        success=False,
+                        error_message="dataset_id is required",
+                    )
+                where = arguments.get("where", "1=1")
+                out_fields = arguments.get("out_fields", "*")
+                limit = arguments.get("limit", 100)
+                filters = {"where": where, "out_fields": out_fields}
+                records = await self.query_data(dataset_id, filters, limit)
+                return ToolResult(
+                    content=[
+                        {
+                            "type": "text",
+                            "text": self._format_query_results(records, limit),
+                        }
+                    ],
+                    success=True,
+                )
+
+            else:
+                return ToolResult(
+                    content=[],
+                    success=False,
+                    error_message=f"Unknown tool: {tool_name}",
+                )
+
+        except Exception as e:
+            logger.error(f"Error executing tool {tool_name}: {e}", exc_info=True)
+            return ToolResult(
+                content=[],
+                success=False,
+                error_message=str(e) if str(e) else "Tool execution failed",
+            )
+
+    # ── DataPlugin abstract method implementations ──────────────────────
+
+    async def search_datasets(
+        self, query: str, limit: int = 10
+    ) -> List[Dict[str, Any]]:
+        try:
+            response = await self.hub_client.get(
+                "/api/search/v1/collections/all/items",
+                params={"q": query, "limit": limit},
+            )
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            raise RuntimeError(
+                f"Hub Search API error (HTTP {e.response.status_code}): "
+                f"{e.response.text}"
+            ) from e
+
+        data = response.json()
+        features = data.get("features", [])
+        if not features:
+            return []
+
+        results = []
+        for feature in features:
+            props = feature.get("properties", {})
+            results.append(self._extract_dataset_summary(props))
+        return results
+
+    async def get_dataset(self, dataset_id: str) -> Dict[str, Any]:
+        try:
+            response = await self.hub_client.get(
+                f"/api/search/v1/collections/all/items/{dataset_id}",
+            )
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            raise RuntimeError(
+                f"Hub Search API error (HTTP {e.response.status_code}): "
+                f"{e.response.text}"
+            ) from e
+
+        feature = response.json()
+        props = feature.get("properties", {})
+
+        result = self._extract_dataset_summary(props)
+        result.update(
+            {
+                "snippet": props.get("snippet", ""),
+                "licenseInfo": props.get("licenseInfo", ""),
+                "spatialReference": props.get("spatialReference", ""),
+                "geometryType": props.get("geometryType", ""),
+                "additionalResources": props.get("additionalResources", []),
+                "numRecords": props.get("numRecords", None),
+                "service_url": props.get("url", ""),
+            }
+        )
+        return result
+
+    async def query_data(
+        self,
+        resource_id: str,
+        filters: Optional[Dict[str, Any]] = None,
+        limit: int = 100,
+    ) -> List[Dict[str, Any]]:
+        dataset = await self.get_dataset(resource_id)
+        service_url = dataset.get("service_url")
+        if not service_url:
+            raise ValueError(
+                f"Dataset {resource_id} does not have a queryable Feature Service URL"
+            )
+
+        where_clause = filters.get("where", "1=1") if filters else "1=1"
+        where_clause = WhereValidator.validate(where_clause)
+        out_fields = filters.get("out_fields", "*") if filters else "*"
+
+        service_url = self._ensure_layer_url(service_url)
+        query_url = f"{service_url}/query"
+        params = {
+            "where": where_clause,
+            "outFields": out_fields,
+            "resultRecordCount": min(limit, 1000),
+            "f": "json",
+            "returnGeometry": "false",
+        }
+
+        try:
+            response = await self.feature_client.get(query_url, params=params)
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            raise RuntimeError(
+                f"Feature Service query error (HTTP {e.response.status_code}): "
+                f"{e.response.text}"
+            ) from e
+
+        data = response.json()
+        features = data.get("features", [])
+        if not features:
+            return []
+
+        return [f.get("attributes", {}) for f in features]
+
+    # ── Aggregations (standalone helper, not a DataPlugin method) ───────
+
+    async def get_aggregations(
+        self, field: str, q: Optional[str] = None
+    ) -> List[Dict[str, Any]]:
+        params: Dict[str, Any] = {"fields": field}
+        if q:
+            params["q"] = q
+
+        try:
+            response = await self.hub_client.get(
+                "/api/search/v1/collections/all/aggregations", params=params
+            )
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            logger.warning(
+                f"Hub Aggregations API error (HTTP {e.response.status_code}): "
+                f"{e.response.text}"
+            )
+            return []
+
+        data = response.json()
+        buckets = data.get("aggregations", {}).get(field, {}).get("buckets", [])
+        return buckets
+
+    # ── Health check ────────────────────────────────────────────────────
+
+    async def health_check(self) -> bool:
+        try:
+            response = await self.hub_client.get("/api/search/v1/collections")
+            return response.status_code == 200
+        except Exception as e:
+            logger.error(f"Health check failed: {e}")
+            return False
+
+    # ── Private helpers ─────────────────────────────────────────────────
+
+    @staticmethod
+    def _ensure_layer_url(service_url: str) -> str:
+        """Append /0 if the URL points at a FeatureServer or MapServer root
+        without a layer index (e.g. .../FeatureServer -> .../FeatureServer/0).
+        """
+        stripped = service_url.rstrip("/")
+        if re.search(r"/(FeatureServer|MapServer)$", stripped, re.IGNORECASE):
+            return f"{stripped}/0"
+        return stripped
+
+    @staticmethod
+    def _epoch_ms_to_iso(epoch_ms: Any) -> str:
+        if epoch_ms is None:
+            return ""
+        try:
+            return datetime.fromtimestamp(int(epoch_ms) / 1000).strftime("%Y-%m-%d")
+        except (ValueError, TypeError, OSError):
+            return ""
+
+    @staticmethod
+    def _extract_dataset_summary(props: Dict[str, Any]) -> Dict[str, Any]:
+        description = props.get("description", "") or ""
+        if len(description) > 300:
+            description = description[:300] + "..."
+
+        return {
+            "id": props.get("id", ""),
+            "title": props.get("title", ""),
+            "description": description,
+            "type": props.get("type", ""),
+            "url": props.get("url", ""),
+            "access": props.get("access", ""),
+            "owner": props.get("owner", ""),
+            "created": ArcGISPlugin._epoch_ms_to_iso(props.get("created")),
+            "modified": ArcGISPlugin._epoch_ms_to_iso(props.get("modified")),
+            "tags": props.get("tags", []),
+            "extent": props.get("extent", []),
+        }
+
+    def _format_search_results(self, datasets: List[Dict[str, Any]]) -> str:
+        if not datasets:
+            return "No datasets found."
+
+        lines = [f"Found {len(datasets)} dataset(s):\n"]
+
+        for i, ds in enumerate(datasets, 1):
+            tags = ", ".join(ds.get("tags", [])) if ds.get("tags") else "None"
+            lines.append(f"{i}. {ds.get('title', 'Untitled')}")
+            lines.append(f"   ID: {ds.get('id', 'unknown')}")
+            lines.append(f"   Type: {ds.get('type', 'unknown')}")
+            lines.append(f"   Access: {ds.get('access', 'unknown')}")
+            lines.append(f"   Description: {ds.get('description', 'No description')}")
+            lines.append(f"   URL: {ds.get('url', '')}")
+            lines.append(f"   Tags: {tags}")
+            lines.append("")
+
+        return "\n".join(lines)
+
+    def _format_dataset(self, dataset: Dict[str, Any]) -> str:
+        tags = ", ".join(dataset.get("tags", [])) if dataset.get("tags") else "None"
+        lines = [
+            f"Dataset: {dataset.get('title', 'Untitled')}",
+            f"ID: {dataset.get('id', 'unknown')}",
+            f"Type: {dataset.get('type', 'unknown')}",
+            f"Access: {dataset.get('access', 'unknown')}",
+            f"Owner: {dataset.get('owner', 'unknown')}",
+            f"Created: {dataset.get('created', '')}",
+            f"Modified: {dataset.get('modified', '')}",
+            f"Description: {dataset.get('description', 'No description')}",
+            f"Snippet: {dataset.get('snippet', '')}",
+            f"License: {dataset.get('licenseInfo', '')}",
+            f"Spatial Reference: {dataset.get('spatialReference', '')}",
+            f"Geometry Type: {dataset.get('geometryType', '')}",
+            f"Number of Records: {dataset.get('numRecords', 'N/A')}",
+            f"Tags: {tags}",
+            f"Extent: {dataset.get('extent', [])}",
+            f"Additional Resources: {dataset.get('additionalResources', [])}",
+            f"URL: {dataset.get('url', '')}",
+            f"Service URL (use for query_data): {dataset.get('service_url', '')}",
+        ]
+        return "\n".join(lines)
+
+    def _format_query_results(self, records: List[Dict[str, Any]], limit: int) -> str:
+        if not records:
+            return "No records returned."
+
+        lines = [f"Returned {len(records)} record(s) (limit: {limit}):\n"]
+
+        for i, record in enumerate(records, 1):
+            lines.append(f"Record {i}:")
+            for key, value in record.items():
+                lines.append(f"  {key}: {value}")
+            lines.append("")
+
+        return "\n".join(lines)
+
+    def _format_aggregations(self, field: str, buckets: List[Dict[str, Any]]) -> str:
+        if not buckets:
+            return f"No aggregation results for '{field}'."
+
+        lines = [f"Aggregations for '{field}':\n"]
+        for bucket in buckets:
+            lines.append(
+                f"  {bucket.get('key', 'unknown')}: "
+                f"{bucket.get('doc_count', 0)} dataset(s)"
+            )
+
+        return "\n".join(lines)

--- a/plugins/arcgis/where_validator.py
+++ b/plugins/arcgis/where_validator.py
@@ -1,0 +1,52 @@
+"""WHERE clause validator for ArcGIS Feature Service queries.
+
+Provides light sanitization of SQL WHERE clauses to prevent
+injection of destructive operations.
+"""
+
+import re
+
+
+class WhereValidator:
+    """Validates WHERE clause strings for Feature Service queries."""
+
+    FORBIDDEN_KEYWORDS = [
+        "INSERT",
+        "UPDATE",
+        "DELETE",
+        "DROP",
+        "TRUNCATE",
+        "ALTER",
+        "CREATE",
+        "EXEC",
+        "EXECUTE",
+    ]
+
+    @classmethod
+    def validate(cls, where: str) -> str:
+        """Validate and sanitize a WHERE clause string.
+
+        Args:
+            where: SQL WHERE clause string
+
+        Returns:
+            The original WHERE clause if valid, or "1=1" if empty/None
+
+        Raises:
+            ValueError: If the clause contains forbidden SQL keywords
+        """
+        if not where:
+            return "1=1"
+
+        where = where.strip()
+        if not where:
+            return "1=1"
+
+        where_upper = where.upper()
+        for keyword in cls.FORBIDDEN_KEYWORDS:
+            if re.search(rf"\b{keyword}\b", where_upper):
+                raise ValueError(
+                    f"Forbidden keyword '{keyword}' detected in WHERE clause"
+                )
+
+        return where

--- a/tests/test_arcgis_plugin.py
+++ b/tests/test_arcgis_plugin.py
@@ -1,0 +1,349 @@
+"""Comprehensive tests for ArcGIS Hub plugin.
+
+These tests verify plugin initialization, tool execution, API interactions,
+error handling, and data formatting. Tests are designed to fail if functionality breaks.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, Mock, patch
+
+import httpx
+from pydantic import ValidationError
+
+from core.interfaces import PluginType
+from plugins.arcgis.config_schema import ArcGISPluginConfig
+from plugins.arcgis.plugin import ArcGISPlugin
+from plugins.arcgis.where_validator import WhereValidator
+
+
+@pytest.fixture
+def arcgis_config():
+    """Standard ArcGIS Hub plugin configuration."""
+    return {
+        "portal_url": "https://hub.arcgis.com",
+        "city_name": "TestCity",
+        "timeout": 120,
+    }
+
+
+# ── Plugin attributes ──────────────────────────────────────────────────
+
+
+class TestPluginAttributes:
+    def test_plugin_attributes(self, arcgis_config):
+        plugin = ArcGISPlugin(arcgis_config)
+        assert plugin.plugin_name == "arcgis"
+        assert plugin.plugin_type == PluginType.OPEN_DATA
+
+
+# ── Initialization ─────────────────────────────────────────────────────
+
+
+class TestInitialization:
+    @pytest.mark.asyncio
+    async def test_initialize_success(self, arcgis_config):
+        plugin = ArcGISPlugin(arcgis_config)
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.raise_for_status = Mock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client_class.return_value = mock_client
+
+            result = await plugin.initialize()
+
+            assert result is True
+            assert plugin._initialized is True
+
+    @pytest.mark.asyncio
+    async def test_initialize_failure(self, arcgis_config):
+        plugin = ArcGISPlugin(arcgis_config)
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(
+                side_effect=httpx.ConnectError("Connection refused")
+            )
+            mock_client_class.return_value = mock_client
+
+            result = await plugin.initialize()
+
+            assert result is False
+            assert plugin._initialized is False
+
+
+# ── get_tools ──────────────────────────────────────────────────────────
+
+
+class TestGetTools:
+    def test_get_tools_returns_four_tools(self, arcgis_config):
+        plugin = ArcGISPlugin(arcgis_config)
+        plugin.plugin_config = ArcGISPluginConfig(**arcgis_config)
+        tools = plugin.get_tools()
+
+        assert len(tools) == 4
+        tool_names = [t.name for t in tools]
+        assert "search_datasets" in tool_names
+        assert "get_dataset" in tool_names
+        assert "get_aggregations" in tool_names
+        assert "query_data" in tool_names
+
+
+# ── execute_tool ───────────────────────────────────────────────────────
+
+
+class TestExecuteTool:
+    @pytest.mark.asyncio
+    async def test_execute_tool_unknown(self, arcgis_config):
+        plugin = ArcGISPlugin(arcgis_config)
+        plugin.plugin_config = ArcGISPluginConfig(**arcgis_config)
+
+        result = await plugin.execute_tool("unknown_tool", {})
+
+        assert result.success is False
+        assert "Unknown tool" in result.error_message
+
+    @pytest.mark.asyncio
+    async def test_execute_tool_search_datasets(self, arcgis_config):
+        plugin = ArcGISPlugin(arcgis_config)
+        plugin.plugin_config = ArcGISPluginConfig(**arcgis_config)
+
+        with patch.object(
+            plugin,
+            "search_datasets",
+            new_callable=AsyncMock,
+            return_value=[
+                {
+                    "id": "abc123",
+                    "title": "Test Dataset",
+                    "tags": [],
+                    "description": "desc",
+                }
+            ],
+        ):
+            result = await plugin.execute_tool("search_datasets", {"q": "test"})
+
+        assert result.success is True
+        assert len(result.content) > 0
+        assert "text" in result.content[0]
+
+    @pytest.mark.asyncio
+    async def test_execute_tool_get_dataset(self, arcgis_config):
+        plugin = ArcGISPlugin(arcgis_config)
+        plugin.plugin_config = ArcGISPluginConfig(**arcgis_config)
+
+        with patch.object(
+            plugin,
+            "get_dataset",
+            new_callable=AsyncMock,
+            return_value={
+                "id": "abc123",
+                "title": "Test",
+                "tags": [],
+                "description": "desc",
+                "service_url": "https://example.com/FeatureServer/0",
+            },
+        ):
+            result = await plugin.execute_tool("get_dataset", {"dataset_id": "abc123"})
+
+        assert result.success is True
+        assert len(result.content) > 0
+
+    @pytest.mark.asyncio
+    async def test_execute_tool_query_data(self, arcgis_config):
+        plugin = ArcGISPlugin(arcgis_config)
+        plugin.plugin_config = ArcGISPluginConfig(**arcgis_config)
+
+        with patch.object(
+            plugin,
+            "query_data",
+            new_callable=AsyncMock,
+            return_value=[{"name": "Park A", "status": "Open"}],
+        ):
+            result = await plugin.execute_tool("query_data", {"dataset_id": "abc123"})
+
+        assert result.success is True
+        assert len(result.content) > 0
+
+    @pytest.mark.asyncio
+    async def test_execute_tool_get_aggregations(self, arcgis_config):
+        plugin = ArcGISPlugin(arcgis_config)
+        plugin.plugin_config = ArcGISPluginConfig(**arcgis_config)
+
+        with patch.object(
+            plugin,
+            "get_aggregations",
+            new_callable=AsyncMock,
+            return_value=[
+                {"key": "Feature Layer", "doc_count": 42},
+                {"key": "Table", "doc_count": 10},
+            ],
+        ):
+            result = await plugin.execute_tool("get_aggregations", {"field": "type"})
+
+        assert result.success is True
+        assert "Feature Layer" in result.content[0]["text"]
+
+
+# ── query_data two-hop resolution ─────────────────────────────────────
+
+
+class TestQueryDataTwoHop:
+    @pytest.mark.asyncio
+    async def test_query_data_two_hop(self, arcgis_config):
+        """Verify query_data calls get_dataset first, then queries the Feature Service."""
+        plugin = ArcGISPlugin(arcgis_config)
+        plugin.plugin_config = ArcGISPluginConfig(**arcgis_config)
+
+        mock_feature_client = AsyncMock()
+        mock_feature_response = Mock()
+        mock_feature_response.status_code = 200
+        mock_feature_response.raise_for_status = Mock()
+        mock_feature_response.json.return_value = {
+            "features": [
+                {"attributes": {"name": "Park A", "status": "Open"}},
+            ]
+        }
+        mock_feature_client.get = AsyncMock(return_value=mock_feature_response)
+        plugin.feature_client = mock_feature_client
+
+        with patch.object(
+            plugin,
+            "get_dataset",
+            new_callable=AsyncMock,
+            return_value={
+                "id": "abc123",
+                "title": "Parks",
+                "service_url": "https://services.arcgis.com/xyz/FeatureServer/0",
+            },
+        ) as mock_get_dataset:
+            records = await plugin.query_data("abc123", {"where": "1=1"}, 100)
+
+        mock_get_dataset.assert_called_once_with("abc123")
+        mock_feature_client.get.assert_called_once()
+        call_args = mock_feature_client.get.call_args
+        assert "/query" in call_args[0][0]
+        assert len(records) == 1
+        assert records[0]["name"] == "Park A"
+
+    @pytest.mark.asyncio
+    async def test_query_data_auto_appends_layer_index(self, arcgis_config):
+        """When service_url ends with /FeatureServer (no layer), /0 is appended."""
+        plugin = ArcGISPlugin(arcgis_config)
+        plugin.plugin_config = ArcGISPluginConfig(**arcgis_config)
+
+        mock_feature_client = AsyncMock()
+        mock_feature_response = Mock()
+        mock_feature_response.status_code = 200
+        mock_feature_response.raise_for_status = Mock()
+        mock_feature_response.json.return_value = {
+            "features": [{"attributes": {"name": "Skate Park"}}]
+        }
+        mock_feature_client.get = AsyncMock(return_value=mock_feature_response)
+        plugin.feature_client = mock_feature_client
+
+        with patch.object(
+            plugin,
+            "get_dataset",
+            new_callable=AsyncMock,
+            return_value={
+                "id": "abc123",
+                "title": "Parks",
+                "service_url": "https://services.arcgis.com/xyz/FeatureServer",
+            },
+        ):
+            records = await plugin.query_data("abc123", {"where": "1=1"}, 100)
+
+        url_called = mock_feature_client.get.call_args[0][0]
+        assert "/FeatureServer/0/query" in url_called
+        assert len(records) == 1
+
+
+# ── Layer URL helper ───────────────────────────────────────────────────
+
+
+class TestEnsureLayerUrl:
+    def test_appends_layer_to_feature_server_root(self):
+        result = ArcGISPlugin._ensure_layer_url(
+            "https://services.arcgis.com/xyz/FeatureServer"
+        )
+        assert result == "https://services.arcgis.com/xyz/FeatureServer/0"
+
+    def test_preserves_existing_layer_index(self):
+        result = ArcGISPlugin._ensure_layer_url(
+            "https://services.arcgis.com/xyz/FeatureServer/3"
+        )
+        assert result == "https://services.arcgis.com/xyz/FeatureServer/3"
+
+    def test_handles_map_server(self):
+        result = ArcGISPlugin._ensure_layer_url(
+            "https://services.arcgis.com/xyz/MapServer"
+        )
+        assert result == "https://services.arcgis.com/xyz/MapServer/0"
+
+    def test_strips_trailing_slash(self):
+        result = ArcGISPlugin._ensure_layer_url(
+            "https://services.arcgis.com/xyz/FeatureServer/"
+        )
+        assert result == "https://services.arcgis.com/xyz/FeatureServer/0"
+
+
+# ── WhereValidator ─────────────────────────────────────────────────────
+
+
+class TestWhereValidator:
+    def test_where_validator_blocks_delete(self):
+        with pytest.raises(ValueError, match="DELETE"):
+            WhereValidator.validate("DELETE FROM x")
+
+    def test_where_validator_allows_valid(self):
+        result = WhereValidator.validate("status = 'Active'")
+        assert result == "status = 'Active'"
+
+    def test_where_validator_empty(self):
+        result = WhereValidator.validate("")
+        assert result == "1=1"
+
+    def test_where_validator_does_not_flag_deleted_at(self):
+        result = WhereValidator.validate("deleted_at IS NULL")
+        assert result == "deleted_at IS NULL"
+
+
+# ── Config schema ──────────────────────────────────────────────────────
+
+
+class TestConfigSchema:
+    def test_config_schema_valid(self):
+        config = ArcGISPluginConfig(
+            portal_url="https://hub.arcgis.com",
+            city_name="Boston",
+            timeout=60,
+        )
+        assert config.city_name == "Boston"
+        assert config.portal_url == "https://hub.arcgis.com"
+        assert config.timeout == 60
+        assert config.token is None
+
+    def test_config_schema_rejects_extra_fields(self):
+        with pytest.raises(ValidationError):
+            ArcGISPluginConfig(
+                portal_url="https://hub.arcgis.com",
+                city_name="Boston",
+                unknown_field="oops",
+            )
+
+    def test_config_schema_strips_trailing_slash(self):
+        config = ArcGISPluginConfig(
+            portal_url="https://hub.arcgis.com/",
+            city_name="Boston",
+        )
+        assert config.portal_url == "https://hub.arcgis.com"
+
+    def test_config_schema_rejects_invalid_url(self):
+        with pytest.raises(ValidationError):
+            ArcGISPluginConfig(
+                portal_url="not-a-url",
+                city_name="Boston",
+            )


### PR DESCRIPTION
This pull request introduces a new ArcGIS Hub plugin for OpenContext, enabling integration with ArcGIS Hub open data portals. The changes include plugin configuration, validation, implementation, and comprehensive tests. The most important changes are grouped below:

**ArcGIS Hub Plugin Implementation:**

* Added a new plugin configuration section for ArcGIS Hub in `config-example.yaml`, allowing users to enable the plugin and specify portal URL, city name, timeout, and optional authentication token.
* Created an `ArcGISPluginConfig` Pydantic schema in `plugins/arcgis/config_schema.py` to validate plugin configuration, including URL validation and strict field enforcement.
* Added a `WhereValidator` utility in `plugins/arcgis/where_validator.py` to sanitize and validate SQL WHERE clauses for safe Feature Service queries.
* Added an `__init__.py` file for the ArcGIS plugin package.

**Testing and Examples:**

* Added comprehensive tests for the ArcGIS Hub plugin in `tests/test_arcgis_plugin.py`, covering initialization, tool execution, API interactions, error handling, data formatting, configuration validation, and WHERE clause validation.
* Updated the example configuration file reference to a new DC ArcGIS example (`config.yaml`).