### PR TITLE
Beta testing fixes for first-time AWS deployment (ArcGIS/DC deployment)

### DIFF
--- a/cli/commands/configure.py
+++ b/cli/commands/configure.py
@@ -20,9 +20,6 @@ from cli.utils import (
 
 PLUGINS = ["CKAN", "Socrata", "ArcGIS"]
 
-# Bucket name must match the `backend "s3"` block in terraform/aws/main.tf.
-TERRAFORM_STATE_BUCKET = "opencontext-terraform-state-govex-dc"
-
 
 def _ensure_state_bucket(bucket_name: str, region: str) -> None:
     """Check that the Terraform S3 state bucket exists; create it if not.
@@ -198,19 +195,8 @@ def _write_tfvars(
 
 
 @friendly_exit
-def configure(
-    state_bucket: str = typer.Option(
-        TERRAFORM_STATE_BUCKET,
-        "--state-bucket",
-        help="S3 bucket name for Terraform state (default: opencontext-terraform-state)",
-    ),
-) -> None:
+def configure() -> None:
     """Interactive wizard to configure your OpenContext MCP server."""
-    # When called programmatically (e.g. in tests), Typer does not resolve
-    # Option defaults — guard against receiving the raw OptionInfo sentinel.
-    if not isinstance(state_bucket, str):
-        state_bucket = TERRAFORM_STATE_BUCKET
-
     project_root = get_project_root()
     terraform_dir = get_terraform_dir()
 
@@ -274,6 +260,19 @@ def configure(
         raise typer.Exit(0)
 
     city_slug = city_name.lower().replace(" ", "-")
+
+    # Prompt for a unique S3 bucket name for Terraform state.
+    # S3 bucket names are globally unique across all AWS accounts, so the
+    # default includes the org city slug to avoid collisions with other
+    # deployments of this project.
+    suggested_bucket = f"opencontext-terraform-state-{city_slug}"
+    state_bucket = questionary.text(
+        "S3 bucket name for Terraform state:",
+        default=suggested_bucket,
+    ).ask()
+    if state_bucket is None:
+        raise typer.Exit(0)
+
     suggested_lambda = f"{city_slug}-opencontext-mcp-{env}"
 
     lambda_name = questionary.text(
@@ -398,6 +397,7 @@ def configure(
     summary.add_row("City", city_name)
     summary.add_row("Environment", env)
     summary.add_row("Plugin", plugin)
+    summary.add_row("Terraform state bucket", state_bucket)
     summary.add_row("Lambda name", lambda_name)
     summary.add_row("AWS region", region)
     summary.add_row("Lambda memory", f"{lambda_memory} MB")

--- a/cli/commands/configure.py
+++ b/cli/commands/configure.py
@@ -21,7 +21,7 @@ from cli.utils import (
 PLUGINS = ["CKAN", "Socrata", "ArcGIS"]
 
 # Bucket name must match the `backend "s3"` block in terraform/aws/main.tf.
-TERRAFORM_STATE_BUCKET = "opencontext-terraform-state"
+TERRAFORM_STATE_BUCKET = "opencontext-terraform-state-govex-dc"
 
 
 def _ensure_state_bucket(bucket_name: str, region: str) -> None:

--- a/cli/commands/validate.py
+++ b/cli/commands/validate.py
@@ -130,36 +130,13 @@ def run_checks(env: str) -> bool:
         ".terraform directory found" if tf_initialized else "Run: opencontext configure",
     ))
 
-    # 7. terraform validate
-    if tf_installed and tf_initialized:
-        try:
-            result = subprocess.run(
-                ["terraform", "validate", "-json"],
-                cwd=terraform_dir,
-                capture_output=True, text=True, timeout=30,
-            )
-            if result.returncode == 0:
-                checks.append(("terraform validate", True, "Configuration valid"))
-            else:
-                error_msg = ""
-                try:
-                    data = json.loads(result.stdout)
-                    error_msg = data.get("error_message", "")
-                except Exception:
-                    pass
-                if not error_msg:
-                    error_msg = (result.stderr or result.stdout or "Validation failed").strip()
-                checks.append(("terraform validate", False, error_msg[:100]))
-        except (FileNotFoundError, subprocess.TimeoutExpired) as e:
-            checks.append(("terraform validate", False, str(e)[:80]))
-    else:
-        checks.append((
-            "terraform validate",
-            False,
-            "Skipped — terraform not installed or not initialized",
-        ))
+    # Note: terraform validate is intentionally skipped here because it
+    # references lambda-deployment.zip, which does not exist until the
+    # packaging step inside `opencontext deploy`. Running validate before
+    # packaging would always fail. Terraform plan (run inside deploy) catches
+    # the same configuration errors after the zip has been created.
 
-    # 8. AWS credentials valid
+    # 7. AWS credentials valid
     try:
         result = subprocess.run(
             ["aws", "sts", "get-caller-identity", "--output", "json"],
@@ -179,7 +156,7 @@ def run_checks(env: str) -> bool:
     except (subprocess.TimeoutExpired, json.JSONDecodeError):
         checks.append(("AWS credentials valid", False, "Run: aws configure"))
 
-    # 9. ACM cert exists for custom domain (only if custom_domain is set)
+    # 8. ACM cert exists for custom domain (only if custom_domain is set)
     if custom_domain:
         try:
             result = subprocess.run(

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 1.0"
 
   backend "s3" {
-    bucket  = "opencontext-terraform-state"
+    bucket  = "opencontext-terraform-state-govex-dc"
     key     = "opencontext/terraform.tfstate"
     region  = "us-east-1"
     encrypt = true

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 1.0"
 
   backend "s3" {
-    bucket  = "opencontext-terraform-state-govex-dc"
+    bucket  = "opencontext-terraform-state"
     key     = "opencontext/terraform.tfstate"
     region  = "us-east-1"
     encrypt = true

--- a/terraform/bootstrap/variables.tf
+++ b/terraform/bootstrap/variables.tf
@@ -7,5 +7,5 @@ variable "aws_region" {
 variable "state_bucket_name" {
   description = "Name of the S3 bucket for Terraform state"
   type        = string
-  default     = "opencontext-terraform-state"
+  default     = "opencontext-terraform-state-govex-dc"
 }

--- a/terraform/bootstrap/variables.tf
+++ b/terraform/bootstrap/variables.tf
@@ -7,5 +7,4 @@ variable "aws_region" {
 variable "state_bucket_name" {
   description = "Name of the S3 bucket for Terraform state"
   type        = string
-  default     = "opencontext-terraform-state-govex-dc"
 }


### PR DESCRIPTION
**Bugs Fixed**

1. S3 terraform state bucket name hardcoded and caused an issue. S3 bucket names are globally unique across all AWS accounts. The default name opencontext-terraform-state is hardcoded (cli/commands/configure.py, terraform/bootstrap/variables.tf, terraform/aws/main.tf) and is already claimed, got a 403 and 409 error. Fixed by adding an interactive prompt in opencontext configure that suggests a unique name based on the city slug and creates the bucket automatically if it doesn't exist.

2. terraform validate fails before Lambda zip exists. Pre-deploy validation runs terraform validate which references lambda-deployment.zip, but that file isn't created until the packaging step inside deploy so can't deploy on a first-time run. Fixed by removing terraform validate from pre-deploy checks, terraform plan (which runs after packaging) catches the same configuration errors (cli/commands/validate.py).


**Other Potential Issues (Not Fixed Yet)**

1. opencontext test incorrectly skips API Gateway URL testing, citing auth requirement even when no custom domain is configured and the URL works fine via curl

2. opencontext test marks 404 responses as passing

3. pyenv rehash lock on Mac blocks opencontext command after install (workaround: rm ~/.pyenv/shims/.pyenv-shim && pyenv rehash).

4. Getting Started, README, and Quickstart docs need some updates. Recommend deleting the Quickstart doc to avoid confusion.

5. uv-based install instructions might be useful, docs only show pip install, but opencontext authenticate checks for uv and the repo uses it internally for Lambda packaging; new deployers could be guided to set up a uv virtual environment from the start

**Testing**
With a few fixes, deployed successfully to AWS staging environment with ArcGIS plugin pointed at https://opendata.dc.gov. Verified with curl and Claude Connector.