### PR TITLE
Bulletin workflow added

### DIFF
--- a/.github/workflows/notify-bulletin.yml
+++ b/.github/workflows/notify-bulletin.yml
@@ -1,0 +1,24 @@
+---
+name: Notify Bulletin
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: github.repository == 'thealphacubicle/OpenContext'
+
+    steps:
+      - name: Publish bulletin
+        run: |
+          curl --fail -X POST https://opencontext-mcp.vercel.app/api/bulletin/publish \
+            -H "Content-Type: application/json" \
+            -H "X-Bulletin-Secret: ${{ secrets.BULLETIN_SECRET }}" \
+            -d '{
+            "commits": ${{ toJson(github.event.commits.*.message) }},
+            "pusher": "${{ github.actor }}",
+            "compare_url": "${{ github.event.compare }}"
+            }'


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate bulletin notifications when changes are pushed to the `main` branch. The workflow triggers a POST request to the bulletin publishing API with commit messages, the pusher's username, and a comparison URL.

**New workflow for automated bulletin notifications:**

* Added `.github/workflows/notify-bulletin.yml` to trigger on pushes to `main`, sending commit messages, pusher info, and compare URL to the bulletin publishing endpoint, using a secret for authentication.