### PR TITLE
fix: opencontext-terraform-state S3 naming conflict

### DIFF
--- a/cli/commands/configure.py
+++ b/cli/commands/configure.py
@@ -21,7 +21,9 @@ from cli.utils import (
 PLUGINS = ["CKAN", "Socrata", "ArcGIS"]
 
 # Bucket name must match the `backend "s3"` block in terraform/aws/main.tf.
-TERRAFORM_STATE_BUCKET = "opencontext-terraform-state"
+def _default_state_bucket() -> str:
+    account_id = boto3.client("sts").get_caller_identity()["Account"]
+    return f"opencontext-terraform-state-{account_id}"
 
 
 def _ensure_state_bucket(bucket_name: str, region: str) -> None:
@@ -41,8 +43,15 @@ def _ensure_state_bucket(bucket_name: str, region: str) -> None:
         return
     except botocore.exceptions.ClientError as e:
         error_code = e.response["Error"]["Code"]
+        if error_code in ("403", "AccessDenied"):
+            console.print(
+                f"[red]Bucket [bold]{bucket_name}[/bold] exists but is owned by "
+                f"another AWS account. Use --state-bucket to specify a unique name.[/red]"
+            )
+            raise typer.Exit(1)
         if error_code not in ("404", "NoSuchBucket"):
-            raise
+            console.print(f"[red]Unexpected S3 error {error_code} for bucket {bucket_name}[/red]")
+            raise typer.Exit(1)
 
     # Bucket does not exist — create it.
     console.print(
@@ -200,16 +209,16 @@ def _write_tfvars(
 @friendly_exit
 def configure(
     state_bucket: str = typer.Option(
-        TERRAFORM_STATE_BUCKET,
+        "",
         "--state-bucket",
-        help="S3 bucket name for Terraform state (default: opencontext-terraform-state)",
+        help="S3 bucket name for Terraform state (default: opencontext-terraform-state-<account-id>)",
     ),
 ) -> None:
     """Interactive wizard to configure your OpenContext MCP server."""
     # When called programmatically (e.g. in tests), Typer does not resolve
     # Option defaults — guard against receiving the raw OptionInfo sentinel.
-    if not isinstance(state_bucket, str):
-        state_bucket = TERRAFORM_STATE_BUCKET
+    if not isinstance(state_bucket, str) or not state_bucket:
+        state_bucket = _default_state_bucket()
 
     project_root = get_project_root()
     terraform_dir = get_terraform_dir()
@@ -350,20 +359,20 @@ def configure(
 
     _ensure_state_bucket(state_bucket, region)
 
-    # Override the backend config at init time so Terraform uses the correct
-    # bucket and region instead of the defaults hard-coded in main.tf.
-    if not (terraform_dir / ".terraform").exists():
-        init_cmd = [
-            "terraform",
-            "init",
-            f"-backend-config=bucket={state_bucket}",
-            f"-backend-config=region={region}",
-        ]
-        run_cmd(
-            init_cmd,
-            cwd=terraform_dir,
-            spinner_msg="Initializing Terraform",
-        )
+    # Always reinitialize with -reconfigure to ensure the backend config is
+    # up to date, even if .terraform already exists from a previous run.
+    init_cmd = [
+        "terraform",
+        "init",
+        "-reconfigure",
+        f"-backend-config=bucket={state_bucket}",
+        f"-backend-config=region={region}",
+    ]
+    run_cmd(
+        init_cmd,
+        cwd=terraform_dir,
+        spinner_msg="Initializing Terraform",
+    )
 
     result = subprocess.run(
         ["terraform", "workspace", "list"],

--- a/terraform/bootstrap/main.tf
+++ b/terraform/bootstrap/main.tf
@@ -27,9 +27,16 @@ provider "aws" {
   region = var.aws_region
 }
 
+data "aws_caller_identity" "current" {}
+
+locals {
+  state_bucket_name = var.state_bucket_name != "" ? var.state_bucket_name : "opencontext-terraform-state-${data.aws_caller_identity.current.account_id}"
+}
+
+
 # S3 bucket for Terraform state
 resource "aws_s3_bucket" "terraform_state" {
-  bucket = var.state_bucket_name
+  bucket = local.state_bucket_name
 
   lifecycle {
     prevent_destroy = true

--- a/terraform/bootstrap/variables.tf
+++ b/terraform/bootstrap/variables.tf
@@ -7,5 +7,5 @@ variable "aws_region" {
 variable "state_bucket_name" {
   description = "Name of the S3 bucket for Terraform state"
   type        = string
-  default     = "opencontext-terraform-state"
+  default     = ""
 }


### PR DESCRIPTION
## Problem

When a new deployer runs `uv run opencontext authenticate`, all checks pass cleanly — Python, uv, AWS CLI, credentials, and Terraform. But then when they run `uv run opencontext configure` and complete the CLI wizard, it fails at the end with no useful explanation:

```
Error: An error occurred (403) when calling the HeadBucket operation: Forbidden
```

The root cause is that the S3 bucket name for Terraform state was hardcoded to `opencontext-terraform-state` in multiple places. S3 bucket names are globally unique across all AWS accounts — this name is already owned by another account, so any new deployer hits a 403 with no actionable error message.

There were three separate issues discovered while fixing this:

---

## Fixes

### 1. Auto-generate a unique S3 bucket name using the AWS account ID

Instead of a hardcoded bucket name, the CLI now calls STS to get the deployer's AWS account ID and generates a name in the format `opencontext-terraform-state-<account-id>` (e.g. `opencontext-terraform-state-716692883178`). This is guaranteed unique per AWS account with no extra user input required. Users can still override it with `--state-bucket` if needed.

Files changed: `cli/commands/configure.py`, `terraform/bootstrap/variables.tf`, `terraform/bootstrap/main.tf`

### 2. Handle 403 with a clear error message instead of crashing

Previously, if a 403 was encountered (bucket owned by another account), the raw AWS `ClientError` bubbled up to Rich's `console.print` which tried to parse the AWS error text as Rich markup. The error message contains `[/:]` which caused a secondary `MarkupError` crash, completely obscuring the real problem. The 403 is now caught explicitly and prints a clear, actionable message:

```
Bucket <name> exists but is owned by another AWS account.
Use --state-bucket to specify a unique name.
```

File changed: `cli/commands/configure.py`

### 3. Always run `terraform init -reconfigure` instead of skipping if `.terraform` exists

The original code skipped `terraform init` if a `.terraform` directory already existed. This caused a second failure on re-runs after the bucket name changed — Terraform detected a backend config change and refused to proceed without reinitialization. Removing the existence check and adding `-reconfigure` ensures the backend config is always in sync.

File changed: `cli/commands/configure.py`

---

## How to reproduce the original bug

1. Clone the repo fresh into a new AWS account
2. Run `uv run opencontext authenticate` — all checks pass
3. Run `uv run opencontext configure` and complete the wizard
4. Observe the 403 error with no explanation at the end

## How to verify the fix

1. Apply this PR
2. Run `uv run opencontext configure` and complete the wizard
3. Observe the bucket is created as `opencontext-terraform-state-<your-account-id>`
4. Configuration completes successfully and prints the summary table
